### PR TITLE
feat: add CLI key management for binary users

### DIFF
--- a/aicp.spec
+++ b/aicp.spec
@@ -63,6 +63,8 @@ a = Analysis(
         'ai_content_pipeline.cli.commands.audio',
         'ai_content_pipeline.cli.commands.imaging',
         'ai_content_pipeline.cli.commands.project',
+        'ai_content_pipeline.cli.commands.keys',
+        'ai_content_pipeline.cli.credentials',
         'ai_content_pipeline.registry',
         'ai_content_pipeline.registry_data',
         'ai_content_pipeline.video_analysis',

--- a/issues/cli-embed-api-keys-in-binary.md
+++ b/issues/cli-embed-api-keys-in-binary.md
@@ -175,7 +175,7 @@ Make the stored credentials available to all downstream services transparently.
 6. **`test_set_key_cli_interactive`** — invoke `aicp set-key FAL_KEY` with simulated prompt input via Click test runner
 7. **`test_set_key_cli_stdin`** — invoke `aicp set-key FAL_KEY --stdin` with piped input via Click test runner
 8. **`test_get_key_cli_masked`** — invoke `aicp get-key FAL_KEY`, verify output is masked
-8. **`test_check_keys_cli_json`** — invoke `aicp check-keys --json`, verify JSON structure
+9. **`test_check_keys_cli_json`** — invoke `aicp check-keys --json`, verify JSON structure
 10. **`test_credentials_file_permissions`** — verify file has `0o600` permissions (Unix only)
 11. **`test_set_key_unknown_warns`** — set an unknown key name, verify warning in output
 12. **`test_set_key_no_positional_value`** — verify that passing a value as a positional arg is rejected

--- a/issues/cli-embed-api-keys-in-binary.md
+++ b/issues/cli-embed-api-keys-in-binary.md
@@ -13,7 +13,7 @@ When users download the `aicp` binary (built via PyInstaller), there is no `.env
 - The `aicp setup` command creates a `.env` template, but this only works in a dev/source context
 - API keys are read from `os.getenv()` — users must `export FAL_KEY=...` every shell session
 - The binary has XDG directory support (`~/.config/video-ai-studio/`) but nothing writes credentials there
-- No `set-key`, `get-key`, or `check-keys` commands exist
+- No `set-key`, `get-key`, `check-keys`, or `delete-key` commands exist
 
 ## Security Threat Model
 
@@ -67,7 +67,7 @@ Create a new module that handles reading/writing API keys to the XDG config dire
 
 ---
 
-### Subtask 2: Add `set-key`, `get-key`, `check-keys` CLI Commands (~8 min)
+### Subtask 2: Add `set-key`, `get-key`, `check-keys`, `delete-key` CLI Commands (~8 min)
 
 Add a new command module for key management commands.
 
@@ -123,6 +123,18 @@ aicp check-keys --json
 ```
 - Checks all known API keys
 - Shows source: `credentials`, `environment`, or `not set`
+- Supports `--json` output
+
+#### `aicp delete-key <KEY_NAME>`
+```bash
+aicp delete-key FAL_KEY
+# Output: ✓ FAL_KEY removed from credentials store
+
+aicp delete-key NONEXISTENT_KEY
+# Output: FAL_KEY not found in credentials store
+```
+- Removes a key from the credentials file
+- Reports success or "not found"
 - Supports `--json` output
 
 **Registration:** Add `register_key_commands` to `cli/commands/__init__.py`

--- a/issues/cli-embed-api-keys-in-binary.md
+++ b/issues/cli-embed-api-keys-in-binary.md
@@ -1,0 +1,189 @@
+# CLI: Embed API Keys into Binary via `set-key` / `get-key` Commands
+
+**Branch:** `feat/cli-embed-fal-key-in-binary`
+**Estimated Time:** ~30 minutes (4 subtasks)
+**Priority:** High — required for standalone binary distribution
+
+---
+
+## Problem
+
+When users download the `aicp` binary (built via PyInstaller), there is no `.env` file and no way to persistently configure API keys. Currently:
+
+- The `aicp setup` command creates a `.env` template, but this only works in a dev/source context
+- API keys are read from `os.getenv()` — users must `export FAL_KEY=...` every shell session
+- The binary has XDG directory support (`~/.config/video-ai-studio/`) but nothing writes credentials there
+- No `set-key`, `get-key`, or `check-keys` commands exist
+
+## Solution
+
+Add three new CLI commands (`set-key`, `get-key`, `check-keys`) that store and retrieve API keys from a persistent credentials file at `~/.config/video-ai-studio/credentials.env`. Then wire the key resolution chain so every service checks this file before falling back to environment variables.
+
+**Key Resolution Order (after implementation):**
+1. Environment variable (e.g., `FAL_KEY`) — always wins for CI/scripting
+2. Credentials file (`~/.config/video-ai-studio/credentials.env`) — persistent storage for binary users
+3. `.env` file in working directory (existing dotenv behavior)
+
+---
+
+## Subtasks
+
+### Subtask 1: Create `credentials.py` — Credential Store Module (~8 min)
+
+Create a new module that handles reading/writing API keys to the XDG config directory.
+
+**New file:** `packages/core/ai_content_pipeline/ai_content_pipeline/cli/credentials.py`
+
+**Responsibilities:**
+- `credentials_path()` → returns `config_dir() / "credentials.env"`
+- `save_key(key_name, key_value)` → writes/updates a key in the credentials file
+- `load_key(key_name)` → reads a specific key from the credentials file
+- `load_all_keys()` → returns dict of all stored keys
+- `delete_key(key_name)` → removes a key from the credentials file
+- `inject_keys()` → loads all stored keys into `os.environ` (only if not already set, so env vars win)
+
+**Key design decisions:**
+- Use simple `KEY=value` format (same as `.env`) — compatible with `python-dotenv`
+- File permissions: `0o600` (owner read/write only) on Unix for security
+- The `inject_keys()` function is the bridge — called early in CLI startup so all downstream code works transparently
+
+**Related files:**
+- `packages/core/ai_content_pipeline/ai_content_pipeline/cli/paths.py` — reuse `config_dir()`, `ensure_dir()`
+
+---
+
+### Subtask 2: Add `set-key`, `get-key`, `check-keys` CLI Commands (~8 min)
+
+Add a new command module for key management commands.
+
+**New file:** `packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/keys.py`
+
+**Commands:**
+
+#### `aicp set-key <KEY_NAME> <KEY_VALUE>`
+```bash
+# Set a single key
+aicp set-key FAL_KEY fal_abc123...
+
+# Set interactively (prompt hides input)
+aicp set-key FAL_KEY --interactive
+```
+- Validates key name against known keys: `FAL_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `ELEVENLABS_API_KEY`
+- Warns (but allows) unknown key names
+- Stores to `~/.config/video-ai-studio/credentials.env`
+- Sets file permissions to `0o600`
+- Supports `--json` output mode
+
+#### `aicp get-key <KEY_NAME>`
+```bash
+aicp get-key FAL_KEY
+# Output: FAL_KEY=fal_abc1...23 (masked middle)
+
+aicp get-key FAL_KEY --reveal
+# Output: FAL_KEY=fal_abc123full_value_here
+```
+- Shows masked value by default (first 6 + last 3 chars)
+- `--reveal` flag shows full value
+- `--json` returns `{"key": "FAL_KEY", "set": true, "source": "credentials"}`
+
+#### `aicp check-keys`
+```bash
+aicp check-keys
+# Output:
+# FAL_KEY        ✓ set (credentials)
+# GEMINI_API_KEY ✓ set (environment)
+# OPENROUTER_API_KEY  ✗ not set
+# ELEVENLABS_API_KEY  ✗ not set
+
+aicp check-keys --json
+# {"keys": [{"name": "FAL_KEY", "set": true, "source": "credentials"}, ...]}
+```
+- Checks all known API keys
+- Shows source: `credentials`, `environment`, or `not set`
+- Supports `--json` output
+
+**Registration:** Add `register_key_commands` to `cli/commands/__init__.py`
+
+**Related files:**
+- `packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/__init__.py` — register new command group
+- `packages/core/ai_content_pipeline/ai_content_pipeline/cli/click_app.py` — import registration
+- `packages/core/ai_content_pipeline/ai_content_pipeline/cli/output.py` — reuse CLIOutput for json/quiet modes
+
+---
+
+### Subtask 3: Wire Key Injection into CLI Startup (~5 min)
+
+Make the stored credentials available to all downstream services transparently.
+
+**Modify:** `packages/core/ai_content_pipeline/ai_content_pipeline/cli/click_app.py`
+
+**Changes:**
+- Import `inject_keys` from `credentials.py`
+- Call `inject_keys()` in the root `cli()` group callback (before any subcommand runs)
+- This ensures `os.environ["FAL_KEY"]` is populated from credentials if not already set
+- All existing service code (`fal_ai.py`, `google.py`, etc.) works without modification
+
+**Why this works:**
+- `inject_keys()` only sets keys that aren't already in the environment
+- Environment variables from shell (`export FAL_KEY=...`) still take priority
+- `.env` files loaded by individual modules can still override (existing behavior preserved)
+- Zero changes needed in provider code (`fal_ai.py`, `google.py`, `openrouter.py`, `elevenlabs.py`)
+
+**Related files:**
+- `packages/core/ai_content_pipeline/ai_content_pipeline/cli/click_app.py:50-67` — the `cli()` callback where injection happens
+- `packages/core/ai_content_platform/services/fal_ai.py:34-37` — unchanged, reads from env
+- `packages/core/ai_content_platform/services/google.py:43-46` — unchanged
+- `packages/core/ai_content_platform/services/openrouter.py:35-38` — unchanged
+- `packages/core/ai_content_platform/services/elevenlabs.py:31-34` — unchanged
+
+---
+
+### Subtask 4: Unit Tests (~9 min)
+
+**New file:** `tests/test_cli_credentials.py`
+
+**Test cases:**
+
+1. **`test_save_and_load_key`** — save a key, load it back, verify match
+2. **`test_load_missing_key`** — load a key that doesn't exist, returns `None`
+3. **`test_delete_key`** — save a key, delete it, verify gone
+4. **`test_inject_keys_respects_env`** — set `FAL_KEY` in env, inject from credentials, verify env value wins
+5. **`test_inject_keys_fills_missing`** — don't set env, inject from credentials, verify it appears in env
+6. **`test_set_key_cli_command`** — invoke `aicp set-key FAL_KEY test123` via Click test runner
+7. **`test_get_key_cli_masked`** — invoke `aicp get-key FAL_KEY`, verify output is masked
+8. **`test_check_keys_cli_json`** — invoke `aicp check-keys --json`, verify JSON structure
+9. **`test_credentials_file_permissions`** — verify file has `0o600` permissions (Unix only)
+10. **`test_set_key_unknown_warns`** — set an unknown key name, verify warning in output
+
+**Test strategy:**
+- Use `tmp_path` fixture to isolate credentials file (monkeypatch `config_dir()`)
+- Use Click's `CliRunner` for CLI command tests
+- Monkeypatch `os.environ` for injection tests
+
+**Related files:**
+- `tests/test_click_app.py` — reference for Click CLI test patterns
+- `tests/test_core.py` — reference for env-based test patterns
+
+---
+
+## File Change Summary
+
+| Action | File Path | Lines |
+|--------|-----------|-------|
+| **CREATE** | `packages/core/ai_content_pipeline/ai_content_pipeline/cli/credentials.py` | ~90 |
+| **CREATE** | `packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/keys.py` | ~120 |
+| **CREATE** | `tests/test_cli_credentials.py` | ~150 |
+| **MODIFY** | `packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/__init__.py` | +3 |
+| **MODIFY** | `packages/core/ai_content_pipeline/ai_content_pipeline/cli/click_app.py` | +5 |
+
+**Total:** ~370 lines added, 2 files modified, 3 files created
+
+---
+
+## Long-Term Considerations
+
+- **Security:** Credentials file uses `0o600` permissions; keys are never logged or shown in `--debug` output
+- **Extensibility:** New API keys can be added by updating the `KNOWN_KEYS` list in `credentials.py`
+- **Backward compatible:** Zero changes to existing provider code; env vars and `.env` still work
+- **Cross-platform:** Uses XDG paths module which already handles Windows (`%APPDATA%`) and Unix (`~/.config/`)
+- **Binary-friendly:** No dependency on working-directory `.env` files; credentials persist in user's home directory

--- a/packages/core/ai_content_pipeline/ai_content_pipeline/cli/click_app.py
+++ b/packages/core/ai_content_pipeline/ai_content_pipeline/cli/click_app.py
@@ -14,6 +14,7 @@ import os
 import click
 
 from .output import CLIOutput
+from .credentials import inject_keys
 from .._version import __version__
 
 
@@ -58,6 +59,10 @@ def cli(ctx, json_mode, quiet, debug, base_dir, config_dir, cache_dir, state_dir
         os.environ["XDG_CACHE_HOME"] = cache_dir
     if state_dir:
         os.environ["XDG_STATE_HOME"] = state_dir
+
+    # Inject stored credentials before any subcommand runs.
+    # Only sets keys not already present in the environment.
+    inject_keys()
 
     # Store shared state for subcommands
     ctx.obj["output"] = CLIOutput(json_mode=json_mode, quiet=quiet, debug=debug)

--- a/packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/__init__.py
+++ b/packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/__init__.py
@@ -10,6 +10,7 @@ from .motion import register_motion_commands
 from .audio import register_audio_commands
 from .imaging import register_imaging_commands
 from .project import register_project_commands
+from .keys import register_key_commands
 
 
 def register_all_commands(cli):
@@ -20,3 +21,4 @@ def register_all_commands(cli):
     register_audio_commands(cli)
     register_imaging_commands(cli)
     register_project_commands(cli)
+    register_key_commands(cli)

--- a/packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/keys.py
+++ b/packages/core/ai_content_pipeline/ai_content_pipeline/cli/commands/keys.py
@@ -1,0 +1,233 @@
+"""
+CLI commands for managing API keys.
+
+Commands:
+- ``set-key``   — store a key via hidden prompt or --stdin
+- ``get-key``   — display a stored key (masked by default)
+- ``check-keys`` — show status of all known API keys
+"""
+
+import os
+import sys
+
+import click
+
+from ..credentials import (
+    KNOWN_KEYS,
+    credentials_path,
+    delete_key,
+    load_all_keys,
+    load_key,
+    save_key,
+)
+
+
+def _mask(value: str) -> str:
+    """Mask all but the first 6 and last 3 characters of a value.
+
+    Args:
+        value: The secret string to mask.
+
+    Returns:
+        Masked string, e.g. ``fal_ab...23``.
+    """
+    if len(value) <= 9:
+        return value[:3] + "..." + value[-2:] if len(value) > 5 else "***"
+    return value[:6] + "..." + value[-3:]
+
+
+def _key_source(key_name: str) -> str:
+    """Determine where a key's value originates.
+
+    If the env value matches the credentials value, the key was injected
+    from credentials — report ``"credentials"`` as the source.
+
+    Returns:
+        ``"environment"``, ``"credentials"``, or ``"not set"``.
+    """
+    cred_value = load_key(key_name)
+    env_value = os.environ.get(key_name)
+    # Reason: inject_keys() copies credential values into os.environ,
+    # so matching values means the source is the credentials file.
+    if cred_value and env_value and cred_value == env_value:
+        return "credentials"
+    if env_value:
+        return "environment"
+    if cred_value:
+        return "credentials"
+    return "not set"
+
+
+# ---------------------------------------------------------------------------
+# set-key
+# ---------------------------------------------------------------------------
+
+@click.command("set-key")
+@click.argument("key_name")
+@click.option("--stdin", "use_stdin", is_flag=True, default=False,
+              help="Read value from stdin (for piping / automation).")
+@click.pass_context
+def set_key(ctx, key_name, use_stdin):
+    """Store an API key securely.
+
+    KEY_NAME is the environment variable name (e.g. FAL_KEY).
+    The value is NEVER passed as a command argument — it is read from an
+    interactive hidden prompt (default) or from stdin (--stdin).
+
+    \b
+    Examples:
+      aicp set-key FAL_KEY                       # interactive prompt
+      echo "$FAL_KEY" | aicp set-key FAL_KEY --stdin  # piped input
+    """
+    out = ctx.obj["output"]
+
+    # Warn on unknown key names
+    if key_name not in KNOWN_KEYS:
+        out.warning(
+            f"'{key_name}' is not a recognised key name. "
+            f"Known keys: {', '.join(KNOWN_KEYS)}"
+        )
+
+    # Read the value — never from argv
+    if use_stdin:
+        if sys.stdin.isatty():
+            out.error("--stdin requires piped input (stdin is a terminal)")
+            ctx.exit(1)
+            return
+        value = sys.stdin.read().strip()
+    else:
+        value = click.prompt(f"Enter value for {key_name}", hide_input=True)
+
+    if not value:
+        out.error("Empty value — key not saved.")
+        ctx.exit(1)
+        return
+
+    path = save_key(key_name, value)
+    out.info(f"{key_name} saved to {path}")
+
+    if ctx.obj.get("json_mode"):
+        out.result(
+            {"key": key_name, "saved": True, "path": str(path)},
+            command="set-key",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get-key
+# ---------------------------------------------------------------------------
+
+@click.command("get-key")
+@click.argument("key_name")
+@click.option("--reveal", is_flag=True, default=False,
+              help="Show the full value instead of a masked version.")
+@click.pass_context
+def get_key(ctx, key_name, reveal):
+    """Display a stored API key (masked by default).
+
+    \b
+    Examples:
+      aicp get-key FAL_KEY            # masked output
+      aicp get-key FAL_KEY --reveal   # full value
+    """
+    out = ctx.obj["output"]
+    value = load_key(key_name)
+    env_value = os.environ.get(key_name)
+    source = _key_source(key_name)
+
+    if ctx.obj.get("json_mode"):
+        out.result(
+            {
+                "key": key_name,
+                "set": bool(value or env_value),
+                "source": source,
+            },
+            command="get-key",
+        )
+        return
+
+    if value:
+        display = value if reveal else _mask(value)
+        out.info(f"{key_name}={display}  (source: credentials)")
+    elif env_value:
+        display = env_value if reveal else _mask(env_value)
+        out.info(f"{key_name}={display}  (source: environment)")
+    else:
+        out.info(f"{key_name} is not set")
+
+
+# ---------------------------------------------------------------------------
+# check-keys
+# ---------------------------------------------------------------------------
+
+@click.command("check-keys")
+@click.pass_context
+def check_keys(ctx):
+    """Show the status of all known API keys.
+
+    \b
+    Examples:
+      aicp check-keys
+      aicp check-keys --json
+    """
+    out = ctx.obj["output"]
+    rows = []
+    for key_name in KNOWN_KEYS:
+        source = _key_source(key_name)
+        is_set = source != "not set"
+        rows.append({"name": key_name, "set": is_set, "source": source})
+
+    if ctx.obj.get("json_mode"):
+        out.result({"keys": rows}, command="check-keys")
+        return
+
+    for row in rows:
+        mark = "set" if row["set"] else "not set"
+        icon = "+" if row["set"] else "-"
+        source_info = f" ({row['source']})" if row["set"] else ""
+        out.info(f"  [{icon}] {row['name']:<25} {mark}{source_info}")
+
+    cred_path = credentials_path()
+    out.info(f"\nCredentials file: {cred_path}")
+
+
+# ---------------------------------------------------------------------------
+# delete-key
+# ---------------------------------------------------------------------------
+
+@click.command("delete-key")
+@click.argument("key_name")
+@click.pass_context
+def delete_key_cmd(ctx, key_name):
+    """Remove a stored API key from the credentials file.
+
+    \b
+    Examples:
+      aicp delete-key FAL_KEY
+    """
+    out = ctx.obj["output"]
+    removed = delete_key(key_name)
+
+    if ctx.obj.get("json_mode"):
+        out.result(
+            {"key": key_name, "deleted": removed},
+            command="delete-key",
+        )
+        return
+
+    if removed:
+        out.info(f"{key_name} removed from credentials.")
+    else:
+        out.info(f"{key_name} was not found in credentials.")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register_key_commands(cli_group):
+    """Register key management commands with the root CLI group."""
+    cli_group.add_command(set_key)
+    cli_group.add_command(get_key)
+    cli_group.add_command(check_keys)
+    cli_group.add_command(delete_key_cmd)

--- a/packages/core/ai_content_pipeline/ai_content_pipeline/cli/credentials.py
+++ b/packages/core/ai_content_pipeline/ai_content_pipeline/cli/credentials.py
@@ -1,0 +1,154 @@
+"""
+Persistent credential storage for API keys.
+
+Stores keys in ``~/.config/video-ai-studio/credentials.env`` (XDG-compliant)
+so that binary users can configure API keys without needing a ``.env`` file
+in the working directory.
+
+Key resolution order (env vars always win):
+1. Environment variable (``FAL_KEY``, etc.) — set by shell or CI
+2. Credentials file — set by ``aicp set-key``
+3. ``.env`` in working directory — existing dotenv behaviour
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+from .paths import config_dir, ensure_dir
+
+# Canonical list of supported API keys and their fallback names.
+KNOWN_KEYS = [
+    "FAL_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ELEVENLABS_API_KEY",
+]
+
+
+def credentials_path() -> Path:
+    """Return the path to the credentials file.
+
+    Returns:
+        Path: ``<config_dir>/credentials.env``
+    """
+    return config_dir() / "credentials.env"
+
+
+def _read_lines() -> list[str]:
+    """Read raw lines from the credentials file."""
+    path = credentials_path()
+    if not path.exists():
+        return []
+    return path.read_text().splitlines()
+
+
+def _write_lines(lines: list[str]) -> None:
+    """Write lines to the credentials file with restricted permissions."""
+    path = credentials_path()
+    ensure_dir(path.parent)
+    path.write_text("\n".join(lines) + "\n" if lines else "")
+    # Reason: restrict to owner-only on Unix to prevent other users reading keys.
+    if sys.platform != "win32":
+        path.chmod(0o600)
+
+
+def load_all_keys() -> Dict[str, str]:
+    """Load all key-value pairs from the credentials file.
+
+    Returns:
+        dict: Mapping of key names to values.
+    """
+    pairs: Dict[str, str] = {}
+    for line in _read_lines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        name, _, value = line.partition("=")
+        pairs[name.strip()] = value.strip()
+    return pairs
+
+
+def load_key(key_name: str) -> Optional[str]:
+    """Load a single key from the credentials file.
+
+    Args:
+        key_name: The environment variable name (e.g. ``FAL_KEY``).
+
+    Returns:
+        The stored value, or ``None`` if not found.
+    """
+    return load_all_keys().get(key_name)
+
+
+def save_key(key_name: str, key_value: str) -> Path:
+    """Save or update a key in the credentials file.
+
+    Args:
+        key_name: The environment variable name.
+        key_value: The secret value.
+
+    Returns:
+        Path to the credentials file.
+    """
+    lines = _read_lines()
+    new_lines: list[str] = []
+    found = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            name, _, _ = stripped.partition("=")
+            if name.strip() == key_name:
+                new_lines.append(f"{key_name}={key_value}")
+                found = True
+                continue
+        new_lines.append(line)
+    if not found:
+        new_lines.append(f"{key_name}={key_value}")
+    _write_lines(new_lines)
+    return credentials_path()
+
+
+def delete_key(key_name: str) -> bool:
+    """Remove a key from the credentials file.
+
+    Args:
+        key_name: The environment variable name.
+
+    Returns:
+        True if the key was found and removed, False otherwise.
+    """
+    lines = _read_lines()
+    new_lines: list[str] = []
+    found = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            name, _, _ = stripped.partition("=")
+            if name.strip() == key_name:
+                found = True
+                continue
+        new_lines.append(line)
+    if found:
+        _write_lines(new_lines)
+    return found
+
+
+def inject_keys() -> int:
+    """Inject stored credentials into ``os.environ``.
+
+    Only sets variables that are **not** already present so that
+    environment variables from the shell always take priority.
+
+    Returns:
+        int: Number of keys injected.
+    """
+    injected = 0
+    for name, value in load_all_keys().items():
+        if name not in os.environ:
+            os.environ[name] = value
+            injected += 1
+    return injected

--- a/tests/test_cli_credentials.py
+++ b/tests/test_cli_credentials.py
@@ -169,8 +169,9 @@ class TestSetKeyCLI:
 
 
 class TestGetKeyCLI:
-    def test_get_key_masked(self, runner):
+    def test_get_key_masked(self, runner, monkeypatch):
         """get-key masks the value by default."""
+        monkeypatch.delenv("FAL_KEY", raising=False)
         save_key("FAL_KEY", "fal_abcdefghijklmnop")
         result = runner.invoke(cli, ["get-key", "FAL_KEY"])
         assert result.exit_code == 0
@@ -179,8 +180,9 @@ class TestGetKeyCLI:
         # The full value should NOT appear
         assert "fal_abcdefghijklmnop" not in result.output
 
-    def test_get_key_reveal(self, runner):
+    def test_get_key_reveal(self, runner, monkeypatch):
         """get-key --reveal shows the full value."""
+        monkeypatch.delenv("FAL_KEY", raising=False)
         save_key("FAL_KEY", "fal_abcdefghijklmnop")
         result = runner.invoke(cli, ["get-key", "FAL_KEY", "--reveal"])
         assert result.exit_code == 0

--- a/tests/test_cli_credentials.py
+++ b/tests/test_cli_credentials.py
@@ -1,0 +1,242 @@
+"""Tests for the CLI credential storage feature (set-key / get-key / check-keys).
+
+Covers:
+- Credential store module (save, load, delete, inject)
+- CLI commands via Click CliRunner
+- Security: file permissions, no positional value arg, masked output
+"""
+
+import os
+import sys
+import stat
+
+import pytest
+from click.testing import CliRunner
+
+from ai_content_pipeline.cli.click_app import cli
+from ai_content_pipeline.cli.credentials import (
+    KNOWN_KEYS,
+    credentials_path,
+    delete_key,
+    inject_keys,
+    load_all_keys,
+    load_key,
+    save_key,
+)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(tmp_path, monkeypatch):
+    """Redirect config_dir to a temp directory for every test."""
+    monkeypatch.setattr(
+        "ai_content_pipeline.cli.credentials.config_dir",
+        lambda: tmp_path,
+    )
+    # Also patch the import used in keys.py for credentials_path display
+    monkeypatch.setattr(
+        "ai_content_pipeline.cli.commands.keys.credentials_path",
+        lambda: tmp_path / "credentials.env",
+    )
+
+
+# ===========================================================================
+# Credential store module tests
+# ===========================================================================
+
+
+class TestCredentialStore:
+    def test_save_and_load_key(self):
+        """Save a key, load it back — values should match."""
+        save_key("FAL_KEY", "fal_test_123")
+        assert load_key("FAL_KEY") == "fal_test_123"
+
+    def test_load_missing_key(self):
+        """Loading a key that doesn't exist returns None."""
+        assert load_key("NONEXISTENT_KEY") is None
+
+    def test_delete_key(self):
+        """Save a key, delete it, verify it's gone."""
+        save_key("FAL_KEY", "fal_test_123")
+        assert delete_key("FAL_KEY") is True
+        assert load_key("FAL_KEY") is None
+
+    def test_delete_missing_key(self):
+        """Deleting a key that doesn't exist returns False."""
+        assert delete_key("NONEXISTENT_KEY") is False
+
+    def test_save_overwrites_existing(self):
+        """Saving the same key twice overwrites the first value."""
+        save_key("FAL_KEY", "old_value")
+        save_key("FAL_KEY", "new_value")
+        assert load_key("FAL_KEY") == "new_value"
+        # Should not duplicate entries
+        all_keys = load_all_keys()
+        assert len([k for k in all_keys if k == "FAL_KEY"]) == 1
+
+    def test_load_all_keys(self):
+        """Multiple keys can be stored and loaded."""
+        save_key("FAL_KEY", "fal_123")
+        save_key("GEMINI_API_KEY", "gem_456")
+        keys = load_all_keys()
+        assert keys == {"FAL_KEY": "fal_123", "GEMINI_API_KEY": "gem_456"}
+
+    def test_inject_keys_fills_missing(self, monkeypatch):
+        """inject_keys sets env vars that are not already present."""
+        save_key("FAL_KEY", "fal_injected")
+        monkeypatch.delenv("FAL_KEY", raising=False)
+
+        count = inject_keys()
+
+        assert count >= 1
+        assert os.environ["FAL_KEY"] == "fal_injected"
+
+    def test_inject_keys_respects_env(self, monkeypatch):
+        """inject_keys does NOT overwrite existing env vars."""
+        save_key("FAL_KEY", "from_credentials")
+        monkeypatch.setenv("FAL_KEY", "from_environment")
+
+        inject_keys()
+
+        assert os.environ["FAL_KEY"] == "from_environment"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix permissions only")
+    def test_credentials_file_permissions(self):
+        """Credentials file should have 0o600 permissions on Unix."""
+        save_key("FAL_KEY", "test")
+        path = credentials_path()
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+
+# ===========================================================================
+# CLI command tests
+# ===========================================================================
+
+
+class TestSetKeyCLI:
+    def test_set_key_interactive(self, runner):
+        """set-key with interactive prompt stores the key."""
+        result = runner.invoke(
+            cli, ["set-key", "FAL_KEY"],
+            input="fal_secret_value\n",
+        )
+        assert result.exit_code == 0
+        assert "FAL_KEY" in result.output
+        assert "saved" in result.output
+        assert load_key("FAL_KEY") == "fal_secret_value"
+
+    def test_set_key_stdin(self, runner, tmp_path, monkeypatch):
+        """set-key --stdin reads value from piped input."""
+        result = runner.invoke(
+            cli, ["set-key", "FAL_KEY", "--stdin"],
+            input="fal_piped_value\n",
+        )
+        assert result.exit_code == 0
+        assert load_key("FAL_KEY") == "fal_piped_value"
+
+    def test_set_key_unknown_warns(self, runner):
+        """Setting an unknown key name prints a warning."""
+        result = runner.invoke(
+            cli, ["set-key", "MY_CUSTOM_KEY"],
+            input="custom_value\n",
+        )
+        assert result.exit_code == 0
+        assert "not a recognised key name" in result.output
+        # But it should still save
+        assert load_key("MY_CUSTOM_KEY") == "custom_value"
+
+    def test_set_key_no_positional_value(self, runner):
+        """Passing extra positional arguments should fail."""
+        result = runner.invoke(
+            cli, ["set-key", "FAL_KEY", "leaked_value"],
+        )
+        # Click should reject the extra argument
+        assert result.exit_code != 0
+
+    def test_set_key_json_output(self, runner):
+        """set-key with --json emits structured output."""
+        result = runner.invoke(
+            cli, ["--json", "set-key", "FAL_KEY"],
+            input="fal_json_test\n",
+        )
+        assert result.exit_code == 0
+        assert '"saved": true' in result.output
+
+
+class TestGetKeyCLI:
+    def test_get_key_masked(self, runner):
+        """get-key masks the value by default."""
+        save_key("FAL_KEY", "fal_abcdefghijklmnop")
+        result = runner.invoke(cli, ["get-key", "FAL_KEY"])
+        assert result.exit_code == 0
+        assert "fal_ab" in result.output
+        assert "nop" in result.output
+        # The full value should NOT appear
+        assert "fal_abcdefghijklmnop" not in result.output
+
+    def test_get_key_reveal(self, runner):
+        """get-key --reveal shows the full value."""
+        save_key("FAL_KEY", "fal_abcdefghijklmnop")
+        result = runner.invoke(cli, ["get-key", "FAL_KEY", "--reveal"])
+        assert result.exit_code == 0
+        assert "fal_abcdefghijklmnop" in result.output
+
+    def test_get_key_not_set(self, runner, monkeypatch):
+        """get-key for a missing key reports not set."""
+        monkeypatch.delenv("FAL_KEY", raising=False)
+        result = runner.invoke(cli, ["get-key", "FAL_KEY"])
+        assert result.exit_code == 0
+        assert "not set" in result.output
+
+    def test_get_key_json(self, runner, monkeypatch):
+        """get-key --json emits structured output."""
+        monkeypatch.delenv("FAL_KEY", raising=False)
+        save_key("FAL_KEY", "fal_test")
+        result = runner.invoke(cli, ["--json", "get-key", "FAL_KEY"])
+        assert result.exit_code == 0
+        assert '"source": "credentials"' in result.output
+
+
+class TestCheckKeysCLI:
+    def test_check_keys_shows_all_known(self, runner):
+        """check-keys lists all known API keys."""
+        result = runner.invoke(cli, ["check-keys"])
+        assert result.exit_code == 0
+        for key in KNOWN_KEYS:
+            assert key in result.output
+
+    def test_check_keys_json(self, runner):
+        """check-keys --json emits structured output."""
+        save_key("FAL_KEY", "fal_test")
+        result = runner.invoke(cli, ["--json", "check-keys"])
+        assert result.exit_code == 0
+        assert '"keys"' in result.output
+        assert '"FAL_KEY"' in result.output
+
+    def test_check_keys_shows_source(self, runner):
+        """check-keys shows correct source for stored keys."""
+        save_key("FAL_KEY", "fal_test")
+        result = runner.invoke(cli, ["check-keys"])
+        assert result.exit_code == 0
+        assert "credentials" in result.output
+
+
+class TestDeleteKeyCLI:
+    def test_delete_key_removes(self, runner):
+        """delete-key removes a stored key."""
+        save_key("FAL_KEY", "fal_test")
+        result = runner.invoke(cli, ["delete-key", "FAL_KEY"])
+        assert result.exit_code == 0
+        assert "removed" in result.output
+        assert load_key("FAL_KEY") is None
+
+    def test_delete_key_missing(self, runner):
+        """delete-key for a missing key reports not found."""
+        result = runner.invoke(cli, ["delete-key", "FAL_KEY"])
+        assert result.exit_code == 0
+        assert "not found" in result.output

--- a/tests/test_cli_credentials.py
+++ b/tests/test_cli_credentials.py
@@ -130,7 +130,7 @@ class TestSetKeyCLI:
         assert "saved" in result.output
         assert load_key("FAL_KEY") == "fal_secret_value"
 
-    def test_set_key_stdin(self, runner, tmp_path, monkeypatch):
+    def test_set_key_stdin(self, runner):
         """set-key --stdin reads value from piped input."""
         result = runner.invoke(
             cli, ["set-key", "FAL_KEY", "--stdin"],


### PR DESCRIPTION
## Summary
- Add `set-key`, `get-key`, `check-keys`, `delete-key` CLI commands for persistent API key storage
- Keys stored in `~/.config/video-ai-studio/credentials.env` with `0o600` permissions
- `inject_keys()` called at CLI startup so all services pick up stored keys transparently
- Key values **never** appear as CLI arguments (hidden prompt or `--stdin` only)

## Security
- No shell history leaks — value input via hidden prompt or `--stdin` pipe
- No process listing leaks — value never in argv
- File permissions `0o600` (owner-only on Unix)
- `get-key` masks output by default

## Test plan
- [x] 23 new unit tests in `tests/test_cli_credentials.py`
- [x] 38 existing CLI tests pass (test_click_app.py)
- [x] 31 existing flag tests pass (test_main_cli_flags.py)
- [x] Manual smoke test of all 4 commands
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds CLI key management commands: set-key, get-key, check-keys, delete-key (interactive and stdin workflows), masked-by-default with optional reveal and JSON output
  * Adds a persistent, XDG-compliant credentials store with restrictive permissions and automatic injection into the CLI environment at startup (env vars remain highest priority)
* **Packaging**
  * Bundled CLI credentials and key-command components are included in the distribution
* **Tests**
  * Comprehensive tests for storage, injection, CLI commands, masking, permissions, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->